### PR TITLE
Replace YAML configuration with Rhai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ version = "1.0.0"
 dependencies = [
  "clap",
  "ncurses",
+ "phf",
  "rand",
  "rhai",
  "serde",
@@ -261,6 +262,48 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
+name = "phf"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1181c94580fa345f50f19d738aaa39c0ed30a600d95cb2d3e23f94266f14fbf"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fb5f6f826b772a8d4c0394209441e7d37cbbb967ae9c7e0e8134365c9ee676"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pkg-config"
@@ -430,6 +473,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,6 @@ dependencies = [
  "rhai",
  "serde",
  "serde_yaml",
- "strum",
  "thiserror",
 ]
 
@@ -460,12 +459,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +244,7 @@ dependencies = [
  "rhai",
  "serde",
  "serde_yaml",
+ "tempfile",
  "thiserror",
 ]
 
@@ -403,6 +413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "rhai"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +544,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,19 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +76,34 @@ checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
+
+[[package]]
+name = "const-random"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368a7a772ead6ce7e1de82bfb04c485f3db8ec744f72925af5735e29a22cc18e"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "proc-macro-hack",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "errno"
@@ -128,6 +169,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,8 +224,11 @@ dependencies = [
  "clap",
  "ncurses",
  "rand",
+ "rhai",
  "serde",
  "serde_yaml",
+ "strum",
+ "thiserror",
 ]
 
 [[package]]
@@ -187,6 +240,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -238,6 +300,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +351,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rhai"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ff176e72a35d975ea0759b1bed69e30ad5cf47580b2e5d00449e8623b5a37dc"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "instant",
+ "num-traits",
+ "rhai_codegen",
+ "smallvec",
+ "smartstring",
+]
+
+[[package]]
+name = "rhai_codegen"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db74e3fdd29d969a0ec1f8e79171a6f0f71d0429293656901db382d248c4c021"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -339,10 +433,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "syn"
@@ -372,6 +495,35 @@ checksum = "cb20089a8ba2b69debd491f8d2d023761cbf196e999218c591fa1e7e15a21907"
 dependencies = [
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +228,7 @@ name = "mendax"
 version = "1.0.0"
 dependencies = [
  "clap",
+ "lazy_static",
  "ncurses",
  "phf",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.0.32", features = ["derive", "env", "wrap_help"] }
+lazy_static = "1.4.0"
 ncurses = "5.101.0"
 phf = { version = "0.11.1", features = ["macros"] }
 rand = "0.8.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,8 @@ edition = "2021"
 clap = { version = "4.0.32", features = ["derive", "env", "wrap_help"] }
 ncurses = "5.101.0"
 rand = "0.8.5"
+rhai = "1.12.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.16"
+strum = "0.24.1"
+thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.0.32", features = ["derive", "env", "wrap_help"] }
 ncurses = "5.101.0"
+phf = { version = "0.11.1", features = ["macros"] }
 rand = "0.8.5"
 rhai = { version = "1.12.0", features = ["no_module"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2021"
 clap = { version = "4.0.32", features = ["derive", "env", "wrap_help"] }
 ncurses = "5.101.0"
 rand = "0.8.5"
-rhai = "1.12.0"
+rhai = { version = "1.12.0", features = ["no_module"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.16"
-strum = "0.24.1"
 thiserror = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ rhai = { version = "1.12.0", features = ["no_module"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.16"
 thiserror = "1.0.38"
+
+[dev-dependencies]
+tempfile = "3.4.0"

--- a/lie.rhai
+++ b/lie.rhai
@@ -21,9 +21,4 @@ lie.look(#{
 
 lie.clear();
 
-// lie.screen(|lie| {
-// 	lie.run("man fdhsajkl", "as");
-// 	lie
-// });
-
 lie.system("ls", "echo asdf");

--- a/lie.rhai
+++ b/lie.rhai
@@ -1,6 +1,9 @@
-lie.fake("echo foo", "foo");
-lie.fake("bar", "fds");
-lie.fake("baz", "r3");
+lie.run("echo foo", "foo");
+lie.run("bar", ["fds", "fdas"]);
+lie.run("baz", "r3");
+
+lie.system("echo asdf");
+lie.system("echo asdf", "echo FDSA<F4><F3><F2>");
 
 lie.prompt(#{
 	user: "methos",
@@ -14,6 +17,6 @@ lie.look(#{
 });
 
 lie.screen(|lie| {
-	lie.fake("man fdhsajkl", "as");
+	lie.run("man fdhsajkl", "as");
 	lie
 });

--- a/lie.rhai
+++ b/lie.rhai
@@ -1,0 +1,26 @@
+lie.fake("echo foo", "foo");
+lie.fake("bar", "fds");
+lie.fake("baz", "r3");
+
+lie.run("echo fda");
+
+lie.prompt(#{
+	user: "methos",
+	host: "gaia",
+	cwd: "root",
+});
+
+lie.look(#{
+	fg: "red",
+	bg: "black",
+});
+
+fn foo(lie) {
+	lie.run("man fdhsajkl");
+	lie
+}
+lie.screen(foo);
+lie.screen(Fn("foo"));
+lie.screen(|lie| {
+	lie.run("man fdhsajkl");
+});

--- a/lie.rhai
+++ b/lie.rhai
@@ -11,9 +11,9 @@ lie.look(#{
 	fg: "red",
 	bg: "black",
 	title: "hfjdkla",
+	cwd: "/",
 	user: "methos",
 	host: "gaia",
-	cwd: "/",
 });
 
 lie.clear();

--- a/lie.rhai
+++ b/lie.rhai
@@ -5,20 +5,17 @@ lie.run("baz", "r3");
 lie.system("echo asdf");
 lie.system("ls", "echo asdf");
 
-lie.prompt(#{
-	user: "methos",
-	host: "gaia",
-	cwd: "/",
-});
-
 lie.run("baz", "r3");
 
 lie.look(#{
 	fg: "red",
 	bg: "black",
 	title: "hfjdkla",
+	user: "methos",
+	host: "gaia",
+	cwd: "/",
 });
 
 lie.clear();
 
-lie.system("ls", "echo asdf");
+lie.system("ls", "super-cool-command-not-ls");

--- a/lie.rhai
+++ b/lie.rhai
@@ -2,8 +2,6 @@ lie.fake("echo foo", "foo");
 lie.fake("bar", "fds");
 lie.fake("baz", "r3");
 
-lie.run("echo fda");
-
 lie.prompt(#{
 	user: "methos",
 	host: "gaia",
@@ -15,12 +13,7 @@ lie.look(#{
 	bg: "black",
 });
 
-fn foo(lie) {
-	lie.run("man fdhsajkl");
-	lie
-}
-lie.screen(foo);
-lie.screen(Fn("foo"));
 lie.screen(|lie| {
-	lie.run("man fdhsajkl");
+	lie.fake("man fdhsajkl", "as");
+	lie
 });

--- a/lie.rhai
+++ b/lie.rhai
@@ -3,20 +3,27 @@ lie.run("bar", ["fds", "fdas"]);
 lie.run("baz", "r3");
 
 lie.system("echo asdf");
-lie.system("echo asdf", "echo FDSA<F4><F3><F2>");
+lie.system("ls", "echo asdf");
 
 lie.prompt(#{
 	user: "methos",
 	host: "gaia",
-	cwd: "root",
+	cwd: "/",
 });
+
+lie.run("baz", "r3");
 
 lie.look(#{
 	fg: "red",
 	bg: "black",
+	title: "hfjdkla",
 });
 
-lie.screen(|lie| {
-	lie.run("man fdhsajkl", "as");
-	lie
-});
+lie.clear();
+
+// lie.screen(|lie| {
+// 	lie.run("man fdhsajkl", "as");
+// 	lie
+// });
+
+lie.system("ls", "echo asdf");

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,7 +8,7 @@ pub struct Args {
     #[arg()]
     init: Option<Init>,
 
-    /// YAML file describing the CLI to spoof [default: cli.yml]
+    /// YAML file describing the CLI to spoof
     #[arg(long, value_name = "spec", default_value_t = String::from("lie.rhai"))]
     spec: String,
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,57 +1,37 @@
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 
 #[derive(Parser)]
 #[command(author, version, about)]
 #[warn(missing_docs)]
 pub struct Args {
-    /// The current working directory of the fake command-line user
-    #[arg(long, default_value = "~")]
-    dir: String,
-
-    /// The host name of the fake command-line machine
-    #[arg(long, env = "HOST", default_value = "ubuntu")]
-    host: String,
+    /// Initialise new mendax project
+    #[arg()]
+    init: Option<Init>,
 
     /// YAML file describing the CLI to spoof [default: cli.yml]
-    #[arg(value_name = "file")]
-    input: Option<String>,
+    #[arg(long, value_name = "spec", default_value_t = String::from("lie.rhai"))]
+    spec: String,
 
-    /// The average time between typed characters
-    #[arg(long, value_name = "ms", default_value = "45")]
-    typing_interval: u32,
-
-    /// The username of the fake command-line user
-    #[arg(long, env = "USER", default_value = "ubuntu")]
-    user: String,
+    /// Allow exectution of arbitrary shell commands
+    #[arg(long = "unsafe")]
+    unrestricted: bool,
 }
 
 impl Args {
-    pub fn dir(&self) -> &str {
-        &self.dir
+    pub fn init(&self) -> &Option<Init> {
+        &self.init
     }
 
-    pub fn host(&self) -> &str {
-        &self.host
+    pub fn input(&self) -> &str {
+        &self.spec
     }
 
-    pub fn input(&self) -> &Option<String> {
-        &self.input
+    pub fn unrestricted(&self) -> bool {
+        self.unrestricted
     }
+}
 
-    pub fn typing_interval(&self) -> u32 {
-        self.typing_interval
-    }
-
-    pub fn user(&self) -> &str {
-        &self.user
-    }
-
-    pub fn ps1(&self, curr_dir: Option<&str>) -> String {
-        format!(
-            "{}@{}:{}$ ",
-            self.user(),
-            self.host(),
-            curr_dir.unwrap_or_else(|| self.dir())
-        )
-    }
+#[derive(ValueEnum, Clone)]
+pub enum Init {
+    Init
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 // use crate::spoof::Spoof;
 use rhai::{
-    Array, CustomType, Engine, EvalAltResult, FnPtr, Map, NativeCallContext, Scope, TypeBuilder,
+    Array, CustomType, Engine, EvalAltResult, Map, Scope, TypeBuilder,
 };
 use thiserror::Error;
 use lazy_static::lazy_static;
@@ -148,14 +148,14 @@ impl Lie {
         Ok(())
     }
 
-    fn screen(ctx: NativeCallContext, lie: &mut Self, f: FnPtr) -> Result<(), Box<EvalAltResult>> {
-        let child = lie.child();
-        let child: Lie = f.call_within_context(&ctx, (child,))?;
+    // fn screen(ctx: NativeCallContext, lie: &mut Self, f: FnPtr) -> Result<(), Box<EvalAltResult>> {
+    //     let child = lie.child();
+    //     let child: Lie = f.call_within_context(&ctx, (child,))?;
 
-        lie.tale.push(Fib::Screen { parts: child.tale });
+    //     lie.tale.push(Fib::Screen { tale: child.tale });
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 }
 
 impl CustomType for Lie {
@@ -167,7 +167,8 @@ impl CustomType for Lie {
             .with_fn("system", Self::system_simple)
             .with_fn("system", Self::system)
             .with_fn("prompt", Self::prompt)
-            .with_fn("screen", Self::screen)
+            // .with_fn("screen", Self::screen)
+            .with_fn("clear", Self::clear)
             .with_fn("look", Self::look);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,10 +53,6 @@ impl Lie {
         &self.tale
     }
 
-    // fn child(&self) -> Self {
-    //     Self::new(self.allow_system)
-    // }
-
     fn run_short(&mut self, cmd: &str, result: &str) {
         self.run(cmd, vec![result.into()])
     }
@@ -149,15 +145,6 @@ impl Lie {
         Ok(())
     }
 
-    // fn screen(ctx: NativeCallContext, lie: &mut Self, f: FnPtr) -> Result<(), Box<EvalAltResult>> {
-    //     let child = lie.child();
-    //     let child: Lie = f.call_within_context(&ctx, (child,))?;
-
-    //     lie.tale.push(Fib::Screen { tale: child.tale });
-
-    //     Ok(())
-    // }
-
     fn clear(&mut self) {
         self.tale.push(Fib::Clear);
     }
@@ -172,7 +159,6 @@ impl CustomType for Lie {
             .with_fn("system", Self::system_simple)
             .with_fn("system", Self::system)
             .with_fn("prompt", Self::prompt)
-            // .with_fn("screen", Self::screen)
             .with_fn("clear", Self::clear)
             .with_fn("look", Self::look);
     }
@@ -237,9 +223,6 @@ pub enum Fib {
         bg: Option<Colour>,
         title: Option<String>,
     },
-    // Screen {
-    //     tale: Tale,
-    // },
     Clear,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 // use crate::spoof::Spoof;
 use lazy_static::lazy_static;
 use rhai::{Array, CustomType, Engine, EvalAltResult, Map, Scope, TypeBuilder};

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,13 +3,13 @@ use lazy_static::lazy_static;
 use rhai::{Array, CustomType, Engine, EvalAltResult, Map, Scope, TypeBuilder};
 use thiserror::Error;
 
-pub fn read(fname: &str, unrestricted: bool) -> Result<Lie, Box<EvalAltResult>> {
+pub fn read<T: AsRef<str>>(fname: T, unrestricted: bool) -> Result<Lie, Box<EvalAltResult>> {
     let engine = engine(unrestricted);
 
     let mut scope = Scope::new();
     scope.push("lie", Lie::new(unrestricted));
 
-    engine.run_file_with_scope(&mut scope, fname.into())?;
+    engine.run_file_with_scope(&mut scope, fname.as_ref().into())?;
 
     Ok(scope.get_value("lie").unwrap())
 }
@@ -91,11 +91,7 @@ impl Lie {
 
     fn system(&mut self, cmd: &str, apparent_cmd: &str) -> Result<(), Box<EvalAltResult>> {
         if !self.allow_system {
-            let problem = MendaxError::SystemForbidden;
-            return Err(Box::new(EvalAltResult::ErrorSystem(
-                        problem.to_string(),
-                        problem.into(),
-            )));
+            return Err(Box::new(MendaxError::SystemForbidden.into()));
         }
 
         let apparent_cmd = apparent_cmd.into();
@@ -130,8 +126,8 @@ impl Lie {
                         expected: vec!["speed", "fg", "bg"],
                     };
                     return Err(Box::new(EvalAltResult::ErrorSystem(
-                                err.to_string(),
-                                Box::new(err),
+                        err.to_string(),
+                        Box::new(err),
                     )));
                 }
             }
@@ -204,11 +200,11 @@ pub enum MendaxError {
 
 impl From<MendaxError> for EvalAltResult {
     fn from(value: MendaxError) -> Self {
-        EvalAltResult::ErrorSystem(value.to_string(), Box::new(value))
+        EvalAltResult::ErrorSystem("mendax error".into(), Box::new(value))
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Fib {
     Run {
         cmd: String,
@@ -224,13 +220,13 @@ pub enum Fib {
         bg: Option<Colour>,
         title: Option<String>,
         cwd: Option<String>,
-        host: Option<String>,
         user: Option<String>,
+        host: Option<String>,
     },
     Clear,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Colour {
     Red,
     Black,
@@ -255,8 +251,150 @@ impl TryFrom<&str> for Colour {
             Ok(*c)
         } else {
             Err(Box::new(
-                    MendaxError::UnknownColour(s.to_owned().into(), &COLOUR_NAMES).into(),
+                MendaxError::UnknownColour(s.to_owned().into(), &COLOUR_NAMES).into(),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::{error::Error, fs};
+
+    fn test_script(unrestricted: bool, script: &str) -> Result<Lie, Box<dyn Error>> {
+        let dir = tempfile::tempdir()?;
+        let lie_path = &dir.path().join("test-lie.rhai");
+
+        fs::write(lie_path, script)?;
+
+        read(lie_path.as_os_str().to_str().unwrap(), unrestricted).map_err(|e| e.into())
+    }
+
+    #[test]
+    fn run() -> Result<(), Box<dyn Error>> {
+        let lie = test_script(
+            false,
+            r#"
+                lie.run("foo");
+                lie.run("bar", "qwer");
+                lie.run("baz", ["asdf", "fdsa"]);
+            "#,
+        )?;
+
+        assert_eq!(
+            lie.tale().fibs(),
+            &[
+                Fib::Run {
+                    cmd: "foo".into(),
+                    result: vec![]
+                },
+                Fib::Run {
+                    cmd: "bar".into(),
+                    result: vec!["qwer".into()]
+                },
+                Fib::Run {
+                    cmd: "baz".into(),
+                    result: vec!["asdf".into(), "fdsa".into()]
+                },
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn system() -> Result<(), Box<dyn Error>> {
+        {
+            let lie = test_script(
+                true,
+                r#"
+                    lie.system("ls");
+                    lie.system("ls -Al", "la");
+                "#,
+            )?;
+
+            assert_eq!(
+                lie.tale().fibs(),
+                &[
+                    Fib::System {
+                        cmd: "ls".into(),
+                        apparent_cmd: "ls".into(),
+                    },
+                    Fib::System {
+                        cmd: "ls -Al".into(),
+                        apparent_cmd: "la".into(),
+                    },
+                ]
+            );
+        }
+
+        {
+            match test_script(false, r#"lie.system("foo");"#) {
+                Err(e) => assert_eq!(
+                    e.to_string(),
+                    "mendax error: system commands are forbidden at this sandbox level"
+                ),
+                _ => assert!(false, "system was allowed"),
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn look() -> Result<(), Box<dyn Error>> {
+        assert_eq!(
+            test_script(false, r#"lie.look(#{});"#)?.tale().fibs(),
+            &[Fib::Look {
+                speed: None,
+                fg: None,
+                bg: None,
+                title: None,
+                cwd: None,
+                host: None,
+                user: None,
+            }],
+        );
+
+        assert_eq!(
+            test_script(
+                false,
+                r#"
+                    lie.look(#{
+                        speed: 100.0,
+                        fg: "black",
+                        bg: "red",
+                        title: "on the origin of electric toasters",
+                        cwd: "~/toast",
+                        user: "methos",
+                        host: "gaia",
+                    });
+                "#
+            )?
+            .tale()
+            .fibs(),
+            &[Fib::Look {
+                speed: Some(100.0),
+                fg: Some(Colour::Black),
+                bg: Some(Colour::Red),
+                title: Some("on the origin of electric toasters".into()),
+                cwd: Some("~/toast".into()),
+                host: Some("gaia".into()),
+                user: Some("methos".into()),
+            }]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn clear() -> Result<(), Box<dyn Error>> {
+        assert_eq!(
+            test_script(false, r#"lie.clear()"#)?.tale().fibs(),
+            &[Fib::Clear]
+        );
+
+        Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,9 +53,9 @@ impl Lie {
         &self.tale
     }
 
-    fn child(&self) -> Self {
-        Self::new(self.allow_system)
-    }
+    // fn child(&self) -> Self {
+    //     Self::new(self.allow_system)
+    // }
 
     fn run_short(&mut self, cmd: &str, result: &str) {
         self.run(cmd, vec![result.into()])

--- a/src/config.rs
+++ b/src/config.rs
@@ -247,11 +247,13 @@ pub enum Fib {
 pub enum Colour {
     Red,
     Black,
+    White,
 }
 
 static COLOURS: phf::Map<&'static str, Colour> = phf::phf_map! {
     "red"   => Colour::Red,
     "black" => Colour::Black,
+    "white" => Colour::White,
 };
 
 lazy_static! {

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,10 @@ impl Lie {
         &self.tale
     }
 
+    fn run_no_output(&mut self, cmd: &str) {
+        self.run(cmd, vec![])
+    }
+
     fn run_short(&mut self, cmd: &str, result: &str) {
         self.run(cmd, vec![result.into()])
     }
@@ -65,6 +69,18 @@ impl Lie {
     fn run(&mut self, cmd: &str, result: Vec<String>) {
         let cmd = cmd.into();
         self.tale.push(Fib::Run { cmd, result });
+    }
+
+    fn cd(&mut self, dir: &str) {
+        self.tale.push(Fib::Run {
+            cmd: format!("cd {dir}"),
+            result: vec![],
+        });
+        self.tale.push(Fib::Prompt {
+            cwd: Some(dir.into()),
+            host: None,
+            user: None,
+        });
     }
 
     fn prompt(&mut self, options: Map) -> Result<(), Box<EvalAltResult>> {
@@ -154,8 +170,10 @@ impl CustomType for Lie {
     fn build(mut builder: TypeBuilder<Self>) {
         builder
             .with_name("Lie")
+            .with_fn("run", Self::run_no_output)
             .with_fn("run", Self::run_short)
             .with_fn("run", Self::run_long)
+            .with_fn("cd", Self::cd)
             .with_fn("system", Self::system_simple)
             .with_fn("system", Self::system)
             .with_fn("prompt", Self::prompt)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,188 @@
+// use crate::spoof::Spoof;
+use rhai::{CustomType, Engine, EvalAltResult, FnPtr, Map, Scope, TypeBuilder, NativeCallContext};
+use thiserror::Error;
+use std::str::FromStr;
+
+pub fn read(fname: &str, allow_run: bool) -> Result<Lie, Box<EvalAltResult>> {
+    let engine = {
+        let mut engine = Engine::new();
+        engine.build_type::<Lie>();
+        engine
+    };
+
+    let mut scope = Scope::new();
+    scope.push("lie", Lie::new(allow_run));
+
+    engine.run_file_with_scope(&mut scope, fname.into())?;
+
+    let lie: Lie = scope.get_value("lie").unwrap();
+    Ok(lie)
+}
+
+#[derive(Clone, Debug)]
+pub struct Lie {
+    parts: Vec<Fib>,
+    allow_run: bool,
+}
+
+impl Lie {
+    fn new(allow_run: bool) -> Self {
+        Self {
+            parts: Vec::new(),
+            allow_run,
+        }
+    }
+
+    fn child(&self) -> Self {
+        Self::new(self.allow_run)
+    }
+
+    pub fn parts(&self) -> &Vec<Fib> {
+        &self.parts
+    }
+
+    fn fake_string(&mut self, cmd: &str, result: &str) -> Result<(), Box<EvalAltResult>> {
+        self.fake_strings(cmd, vec![result])
+    }
+
+    fn fake_strings(&mut self, cmd: &str, result: Vec<&str>) -> Result<(), Box<EvalAltResult>> {
+        if !self.allow_run {
+            let problem = MendaxError::RunForbidden;
+            return Err(Box::new(EvalAltResult::ErrorSystem(
+                problem.to_string(),
+                problem.into(),
+            )));
+        }
+
+        let cmd = cmd.into();
+        let result = result.into_iter().map(ToOwned::to_owned).collect();
+        self.parts.push(Fib::Fake { cmd, result });
+
+        Ok(())
+    }
+
+    fn prompt(&mut self, options: Map) -> Result<(), Box<EvalAltResult>> {
+        let mut cwd = None;
+        let mut host = None;
+        let mut user = None;
+
+        for (k, v) in options.iter() {
+            match k.as_str() {
+                "cwd" => cwd = Some(v.clone().cast()),
+                "host" => host = Some(v.clone().cast()),
+                "user" => user = Some(v.clone().cast()),
+                _ => {
+                    let err = MendaxError::UnknownField {
+                        field: k.as_str().to_owned(),
+                        expected: vec!["cwd", "host", "user"],
+                    };
+                    return Err(Box::new(EvalAltResult::ErrorSystem(
+                        err.to_string(),
+                        Box::new(err),
+                    )));
+                }
+            }
+        }
+
+        self.parts.push(Fib::Prompt { cwd, host, user });
+
+        Ok(())
+    }
+
+    fn run(&mut self, cmd: &str) {
+        self.parts.push(Fib::Run { cmd: cmd.into() })
+    }
+
+    fn look(&mut self, options: Map) -> Result<(), Box<EvalAltResult>> {
+        let mut speed = None;
+        let mut fg = None;
+        let mut bg = None;
+
+        for (k, v) in options.iter() {
+            match k.as_str() {
+                "speed" => speed = Some(v.clone().cast()),
+                "fg" => fg = Some(v.clone().cast().try_into()),
+                "bg" => bg = Some(v.clone().cast().try_into()),
+                _ => {
+                    let err = MendaxError::UnknownField {
+                        field: k.as_str().to_owned(),
+                        expected: vec!["speed", "fg", "bg"],
+                    };
+                    return Err(Box::new(EvalAltResult::ErrorSystem(
+                        err.to_string(),
+                        Box::new(err),
+                    )));
+                }
+            }
+        }
+
+        self.parts.push(Fib::Look { speed, fg, bg });
+
+        Ok(())
+    }
+
+    fn screen(ctx: NativeCallContext, lie: &mut Self, f: FnPtr) -> Result<(), Box<EvalAltResult>> {
+        // println!("{:?}", ctx);
+        let child = lie.child();
+        let child: Lie = f.call_within_context(&ctx, (std::rc::Rc::new(std::sync::Mutex::new(child)),))?;
+
+        lie.parts.push(Fib::Screen { parts: child.parts.clone() });
+
+        Ok(())
+    }
+}
+
+impl CustomType for Lie {
+    fn build(mut builder: TypeBuilder<Self>) {
+        builder
+            .with_name("Lie")
+            .with_fn("fake", Self::fake_string)
+            .with_fn("fake", Self::fake_strings)
+            .with_fn("run", Self::run)
+            .with_fn("prompt", Self::prompt)
+            .with_fn("screen", Self::screen)
+            .with_fn("look", Self::look);
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum MendaxError {
+    #[error("unknown field {field:?} expected one of {expected:?}")]
+    UnknownField {
+        field: String,
+        expected: Vec<&'static str>,
+    },
+
+    #[error("run commands are forbidden at this sandbox level")]
+    RunForbidden,
+}
+
+#[derive(Clone, Debug)]
+pub enum Fib {
+    Fake {
+        cmd: String,
+        result: Vec<String>,
+    },
+    Prompt {
+        cwd: Option<String>,
+        host: Option<String>,
+        user: Option<String>,
+    },
+    Run {
+        cmd: String,
+    },
+    Look {
+        speed: Option<f64>,
+        fg: Option<String>, // TODO(kcza): get format the colours!
+        bg: Option<String>,
+    },
+    Screen {
+        parts: Vec<Fib>,
+    },
+}
+
+// #[derive(strum_macros::EnumString)]
+// pub enum Colour {
+//     Red,
+//     Black
+// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> ExitCode {
         }
     };
 
-    for fib in tale.fibs() {
+    for fib in tale.tale().fibs() {
         println!("{fib:?}");
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,37 +6,31 @@ use crate::args::Args;
 use clap::Parser;
 // use crate::spoof::Spoof;
 // use std::env;
-use std::fs::File;
+use std::fs::OpenOptions;
 use std::io::{self, BufWriter, Write};
 use std::process::ExitCode;
 
 const EXAMPLE: &str = r#"
-- cmd: mendax --help
-- print: |
-    A CLI spoofer
+lie.look(#{ title: "legit demo" });
 
-    Usage: mendax [OPTIONS] [file]
+lie.run("echo Hello, world", "Hello, world");
+lie.run("echo 'All of this is fake'", "'All of this is fake'");
 
-    Arguments:
-      [file]  YAML file describing the CLI to spoof [default: cli.yml]
+lie.cd("~");
 
-    Options:
-          --dir <DIR>             The current working directory of the fake command-line user [default: ~]
-          --host <HOST>           The host name of the fake command-line machine [env: HOST=] [default: ubuntu]
-          --typing-interval <ms>  The average time between typed characters [default: 45]
-          --user <USER>           The username of the fake command-line user [env: USER=kcza] [default: ubuntu]
-      -h, --help                  Print help information
-      -V, --version               Print version information
-- cmd: ls
-- print: |
-    cli.yml
-- cmd: cat cli.yml
-- print:
-    - "- cmd: mendax --help"
-    - "- print: |"
-    - "    A CLI spoofer"
-    - "..."
-    "#;
+lie.run("ls -A1", [
+    ".bash_history",
+    ".bashrc",
+    ".cargo",
+    ".rustup",
+    ".vimrc",
+    ".zshrc",
+    "Desktop",
+    "Documents",
+    "Downloads",
+    "snap",
+]);
+"#;
 
 fn main() -> ExitCode {
     let args = Args::parse();
@@ -103,7 +97,7 @@ fn main() -> ExitCode {
 }
 
 fn init_example(fname: &str) -> io::Result<()> {
-    let f = File::create(fname)?;
+    let f = OpenOptions::new().create_new(true).open(fname)?;
     let mut w = BufWriter::new(f);
 
     write!(w, "{}", &EXAMPLE[1..])?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> ExitCode {
     let fname = args.input();
 
     if args.init().is_some() {
-        return match init_example() {
+        return match init_example(fname) {
             Ok(()) => ExitCode::SUCCESS,
             Err(e) => {
                 eprintln!("{}", e);
@@ -102,8 +102,8 @@ fn main() -> ExitCode {
     // ncurses::endwin();
 }
 
-fn init_example() -> io::Result<()> {
-    let f = File::create("cli.yml")?;
+fn init_example(fname: &str) -> io::Result<()> {
+    let f = File::create(fname)?;
     let mut w = BufWriter::new(f);
 
     write!(w, "{}", &EXAMPLE[1..])?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 mod args;
-mod spoof;
+// mod spoof;
+mod config;
 
-use args::Args;
+use crate::args::Args;
 use clap::Parser;
-use spoof::Spoof;
-use std::env;
+// use crate::spoof::Spoof;
+// use std::env;
 use std::fs::File;
 use std::io::{BufWriter, Write};
 
@@ -38,46 +39,50 @@ const EXAMPLE: &str = r#"
 
 fn main() {
     let args = Args::parse();
-    let input_fname = args.input();
+    let fname = args.input();
 
-    if input_fname == &Some("init".into()) {
-        init_example();
-        return;
+    if args.init().is_some() {
+        return init_example();
     }
 
-    let default_file = String::from("cli.yml");
-    let fname = input_fname.as_ref().unwrap_or(&default_file);
-    let spoof = match Spoof::from_file(&fname) {
-        Ok(s) => s,
-        Err(e) => {
-            if input_fname.is_none() && e.downcast_ref::<std::io::Error>().is_some() {
-                eprintln!(
-                    "no such file '{}'\nrun `{} init` to create an example file",
-                    fname,
-                    env::args().next().unwrap()
-                );
-            } else {
-                eprintln!("error parsing file '{}': {}", fname, e);
-            }
-            return;
-        }
-    };
+    for part in config::read(fname, args.unrestricted()).unwrap().parts() {
+        println!("{part:?}");
+    }
 
-    ncurses::initscr();
-    ncurses::noecho();
+    // let spoof = match Spoof::from_file(fname) {
+    //     Ok(s) => s,
+    //     Err(e) => {
+    //         if e.downcast_ref::<std::io::Error>().is_some() {
+    //             eprintln!(
+    //                 "no such file '{}'\nrun `{} init` to create an example file",
+    //                 fname,
+    //                 env::args().next().unwrap()
+    //             );
+    //         } else {
+    //             eprintln!("error parsing file '{}': {}", fname, e);
+    //         }
+    //         return;
+    //     }
+    // };
 
-    let window = {
-        let mut lines = 0;
-        let mut cols = 0;
-        ncurses::getmaxyx(ncurses::stdscr(), &mut cols, &mut lines);
-        ncurses::newwin(cols, lines, 0, 0)
-    };
-    ncurses::scrollok(window, true);
+    // ncurses::initscr();
+    // ncurses::noecho();
 
-    spoof.run(&args, window);
+    // let window = {
+    //     let mut lines = 0;
+    //     let mut cols = 0;
+    //     ncurses::getmaxyx(ncurses::stdscr(), &mut cols, &mut lines);
+    //     ncurses::newwin(cols, lines, 0, 0)
+    // };
+    // ncurses::scrollok(window, true);
 
-    ncurses::delwin(window);
-    ncurses::endwin();
+    // spoof.run(&args, window);
+
+    // // Hang before exit
+    // ncurses::wgetch(window);
+
+    // ncurses::delwin(window);
+    // ncurses::endwin();
 }
 
 fn init_example() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() {
         return init_example();
     }
 
-    for part in config::read(fname, args.unrestricted()).unwrap().parts() {
+    for part in config::read(fname, args.unrestricted()).unwrap().fibs() {
         println!("{part:?}");
     }
 

--- a/src/spoof.rs
+++ b/src/spoof.rs
@@ -49,11 +49,11 @@ impl Spoof {
     }
 }
 
-// impl From<Vec<Stage>> for Spoof {
-//     fn from(stages: Vec<Stage>) -> Self {
-//         Self { stages }
-//     }
-// }
+impl From<Vec<Stage>> for Spoof {
+    fn from(stages: Vec<Stage>) -> Self {
+        Self { stages }
+    }
+}
 
 #[derive(Deserialise, Debug)]
 #[serde(untagged)]

--- a/src/spoof.rs
+++ b/src/spoof.rs
@@ -11,7 +11,7 @@ use std::{thread, time::Duration};
 #[serde(transparent)]
 pub struct Spoof {
     #[serde(flatten)]
-    stages: Vec<Stage>,
+    pub stages: Vec<Stage>,
 }
 
 impl Spoof {
@@ -48,6 +48,12 @@ impl Spoof {
         .render(args, window)
     }
 }
+
+// impl From<Vec<Stage>> for Spoof {
+//     fn from(stages: Vec<Stage>) -> Self {
+//         Self { stages }
+//     }
+// }
 
 #[derive(Deserialise, Debug)]
 #[serde(untagged)]


### PR DESCRIPTION
The YAML system was janky, difficult to describe and felt vulnerable to the future addition of hacky programmatic abstractions.

This PR replaces this with Rhai to allow a user to more cleanly and more intuitively tell their lie.
