### PR TITLE
Add `lie.screen` support

### DIFF
--- a/lie.rhai
+++ b/lie.rhai
@@ -3,7 +3,7 @@ lie.run("bar", ["fds", "fdas"]);
 lie.run("baz", "r3");
 
 lie.system("echo asdf");
-lie.system("ls", "echo asdf");
+lie.system("echo asdf", "ls");
 
 lie.run("baz", "r3");
 
@@ -16,6 +16,11 @@ lie.look(#{
 	host: "gaia",
 });
 
-lie.clear();
-
-lie.system("ls", "super-cool-command-not-ls");
+for cmd in ["foo", "bar", "baz"] {
+	lie.screen("man " + cmd, |lie| {
+		lie.show("hello, this is the manual page for " + cmd);
+		lie.show("unfortunately this does not currently exist");
+		lie.show("...");
+		lie.show("sorry not sorry");
+	})
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,22 +1,28 @@
-// use crate::spoof::Spoof;
 use lazy_static::lazy_static;
-use rhai::{Array, CustomType, Dynamic, Engine, EvalAltResult, Map, Scope, TypeBuilder};
+use rhai::{
+    Array, CustomType, Dynamic, Engine, EvalAltResult, FnPtr, Map, NativeCallContext, Scope,
+    TypeBuilder,
+};
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+};
 use thiserror::Error;
 
 pub fn read<T: AsRef<str>>(fname: T, unrestricted: bool) -> Result<Lie, Box<EvalAltResult>> {
     let engine = engine(unrestricted);
 
     let mut scope = Scope::new();
-    scope.push("lie", Lie::new(unrestricted));
+    scope.push("lie", SharedLieBuilder::new(unrestricted));
 
     engine.run_file_with_scope(&mut scope, fname.as_ref().into())?;
 
-    Ok(scope.get_value("lie").unwrap())
+    scope.get_value::<SharedLieBuilder>("lie").unwrap().build()
 }
 
 fn engine(unrestricted: bool) -> Engine {
     let mut engine = Engine::new();
-    engine.build_type::<Lie>();
+    engine.build_type::<SharedLieBuilder>();
 
     if !unrestricted {
         engine.set_max_array_size(1000);
@@ -33,22 +39,174 @@ fn engine(unrestricted: bool) -> Engine {
     engine
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Lie {
     tale: Tale,
-    allow_system: bool,
 }
 
 impl Lie {
-    fn new(allow_system: bool) -> Self {
-        Self {
-            tale: Tale::new(),
-            allow_system,
-        }
+    fn new(tale: Tale) -> Self {
+        Self { tale }
     }
 
     pub fn tale(&self) -> &Tale {
         &self.tale
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SharedLieBuilder(Rc<RefCell<LieBuilder>>);
+
+impl From<LieBuilder> for SharedLieBuilder {
+    fn from(lie: LieBuilder) -> Self {
+        Self(Rc::new(RefCell::new(lie)))
+    }
+}
+
+impl SharedLieBuilder {
+    fn new(allow_system: bool) -> Self {
+        Self::from(LieBuilder::new(allow_system))
+    }
+
+    fn build(self) -> Result<Lie, Box<EvalAltResult>> {
+        Ok(Lie::new(
+            self.0
+                .try_borrow()
+                .map_err(|e| EvalAltResult::ErrorSystem("lie in use".into(), Box::new(e)))?
+                .tale
+                .clone(),
+        ))
+    }
+
+    fn lie(&self, ctx: &NativeCallContext) -> Result<Ref<'_, LieBuilder>, Box<EvalAltResult>> {
+        self.0.try_borrow().map_err(|e| {
+            Box::new(EvalAltResult::ErrorDataRace(
+                format!("failed to read lie: {e}"),
+                ctx.position(),
+            ))
+        })
+    }
+
+    fn lie_mut(
+        &self,
+        ctx: &NativeCallContext,
+    ) -> Result<RefMut<'_, LieBuilder>, Box<EvalAltResult>> {
+        self.0.try_borrow_mut().map_err(|e| {
+            Box::new(EvalAltResult::ErrorDataRace(
+                format!("failed to read lie: {e}"),
+                ctx.position(),
+            ))
+        })
+    }
+
+    fn run_no_output(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        cmd: &str,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.run_no_output(cmd);
+        Ok(())
+    }
+
+    fn run_short(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        cmd: &str,
+        result: &str,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.run_short(cmd, result);
+        Ok(())
+    }
+
+    fn run_long(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        cmd: &str,
+        result: Array,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.run_long(cmd, result)
+    }
+
+    fn show(ctx: NativeCallContext, lie: &mut Self, text: &str) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.show(text);
+        Ok(())
+    }
+
+    fn cd(ctx: NativeCallContext, lie: &mut Self, dir: &str) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.cd(dir);
+        Ok(())
+    }
+
+    fn system_simple(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        cmd: &str,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.system_simple(cmd)
+    }
+
+    fn system(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        apparent_cmd: &str,
+        cmd: &str,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.system(Some(apparent_cmd), cmd)
+    }
+
+    fn screen_simple(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        f: FnPtr,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.screen_simple(ctx, f)
+    }
+
+    fn screen(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        apparent_cmd: &str,
+        f: FnPtr,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.screen(ctx, Some(apparent_cmd), f)
+    }
+
+    fn look(
+        ctx: NativeCallContext,
+        lie: &mut Self,
+        options: Map,
+    ) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.look(options)
+    }
+
+    fn clear(ctx: NativeCallContext, lie: &mut Self) -> Result<(), Box<EvalAltResult>> {
+        lie.lie_mut(&ctx)?.clear();
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct LieBuilder {
+    tale: Tale,
+    allow_system: bool,
+    root: bool,
+}
+
+impl LieBuilder {
+    fn new(allow_system: bool) -> Self {
+        Self {
+            tale: Tale::new(),
+            allow_system,
+            root: true,
+        }
+    }
+
+    fn child(&self) -> Self {
+        Self {
+            tale: Tale::new(),
+            allow_system: self.allow_system,
+            root: false,
+        }
     }
 
     fn run_no_output(&mut self, cmd: &str) {
@@ -69,6 +227,11 @@ impl Lie {
         self.tale.push(Fib::Run { cmd, result });
     }
 
+    fn show(&mut self, text: &str) {
+        let text = text.into();
+        self.tale.push(Fib::Show { text });
+    }
+
     fn cd(&mut self, dir: &str) {
         self.tale.push(Fib::Run {
             cmd: format!("cd {dir}"),
@@ -82,21 +245,51 @@ impl Lie {
             bg: None,
             speed: None,
             title: None,
+            final_prompt: None,
         });
     }
 
     fn system_simple(&mut self, cmd: &str) -> Result<(), Box<EvalAltResult>> {
-        self.system(cmd, cmd)
+        self.system(None, cmd)
     }
 
-    fn system(&mut self, cmd: &str, apparent_cmd: &str) -> Result<(), Box<EvalAltResult>> {
+    fn system(&mut self, apparent_cmd: Option<&str>, cmd: &str) -> Result<(), Box<EvalAltResult>> {
         if !self.allow_system {
             return Err(Box::new(MendaxError::SystemForbidden.into()));
         }
 
-        let apparent_cmd = apparent_cmd.into();
+        let apparent_cmd = apparent_cmd.map(ToOwned::to_owned);
         let cmd = cmd.into();
         self.tale.push(Fib::System { apparent_cmd, cmd });
+
+        Ok(())
+    }
+
+    fn screen_simple(
+        &mut self,
+        ctx: NativeCallContext,
+        f: FnPtr,
+    ) -> Result<(), Box<EvalAltResult>> {
+        self.screen(ctx, None, f)
+    }
+
+    fn screen(
+        &mut self,
+        ctx: NativeCallContext,
+        apparent_cmd: Option<&str>,
+        f: FnPtr,
+    ) -> Result<(), Box<EvalAltResult>> {
+        if !self.root {
+            return Err(Box::new(MendaxError::NestedScreens.into()));
+        }
+
+        let child = SharedLieBuilder::from(self.child());
+        f.call_within_context(&ctx, (child.clone(),))?;
+
+        self.tale.push(Fib::Screen {
+            apparent_cmd: apparent_cmd.map(ToOwned::to_owned),
+            tale: child.lie(&ctx)?.tale.clone(),
+        });
 
         Ok(())
     }
@@ -109,62 +302,46 @@ impl Lie {
         let mut cwd = None;
         let mut host = None;
         let mut user = None;
+        let mut final_prompt = None;
 
         {
             #[allow(clippy::type_complexity)]
             let mut action_list: [(
-                &'static str,
-                Box<dyn FnMut(Dynamic) -> Result<(), Box<EvalAltResult>>>,
-            ); 7] = [
-                (
-                    "speed",
-                    Box::new(|v: Dynamic| {
-                        speed = v.cast();
-                        Ok(())
-                    }),
-                ),
-                (
-                    "fg",
-                    Box::new(|v: Dynamic| {
-                        fg = Some(v.cast::<String>().as_str().try_into()?);
-                        Ok(())
-                    }),
-                ),
-                (
-                    "bg",
-                    Box::new(|v: Dynamic| {
-                        bg = Some(v.cast::<String>().as_str().try_into()?);
-                        Ok(())
-                    }),
-                ),
-                (
-                    "title",
-                    Box::new(|v: Dynamic| {
-                        title = Some(v.cast());
-                        Ok(())
-                    }),
-                ),
-                (
-                    "cwd",
-                    Box::new(|v: Dynamic| {
-                        cwd = Some(v.cast());
-                        Ok(())
-                    }),
-                ),
-                (
-                    "host",
-                    Box::new(|v: Dynamic| {
-                        host = Some(v.cast());
-                        Ok(())
-                    }),
-                ),
-                (
-                    "user",
-                    Box::new(|v: Dynamic| {
-                        user = Some(v.cast());
-                        Ok(())
-                    }),
-                ),
+                &str,
+                &mut dyn FnMut(Dynamic) -> Result<(), Box<EvalAltResult>>,
+            ); 8] = [
+                ("speed", &mut |v: Dynamic| {
+                    speed = Some(v.cast());
+                    Ok(())
+                }),
+                ("fg", &mut |v: Dynamic| {
+                    fg = Some(v.cast::<String>().as_str().try_into()?);
+                    Ok(())
+                }),
+                ("bg", &mut |v: Dynamic| {
+                    bg = Some(v.cast::<String>().as_str().try_into()?);
+                    Ok(())
+                }),
+                ("title", &mut |v: Dynamic| {
+                    title = Some(v.cast());
+                    Ok(())
+                }),
+                ("cwd", &mut |v: Dynamic| {
+                    cwd = Some(v.cast());
+                    Ok(())
+                }),
+                ("host", &mut |v: Dynamic| {
+                    host = Some(v.cast());
+                    Ok(())
+                }),
+                ("user", &mut |v: Dynamic| {
+                    user = Some(v.cast());
+                    Ok(())
+                }),
+                ("final_prompt", &mut |v: Dynamic| {
+                    final_prompt = Some(v.cast());
+                    Ok(())
+                }),
             ];
 
             for (k, v) in options.iter() {
@@ -204,6 +381,7 @@ impl Lie {
             cwd,
             host,
             user,
+            final_prompt,
         });
 
         Ok(())
@@ -214,22 +392,25 @@ impl Lie {
     }
 }
 
-impl CustomType for Lie {
+impl CustomType for SharedLieBuilder {
     fn build(mut builder: TypeBuilder<Self>) {
         builder
             .with_name("Lie")
             .with_fn("run", Self::run_no_output)
             .with_fn("run", Self::run_short)
             .with_fn("run", Self::run_long)
+            .with_fn("show", Self::show)
             .with_fn("cd", Self::cd)
             .with_fn("system", Self::system_simple)
             .with_fn("system", Self::system)
-            .with_fn("clear", Self::clear)
-            .with_fn("look", Self::look);
+            .with_fn("screen", Self::screen_simple)
+            .with_fn("screen", Self::screen)
+            .with_fn("look", Self::look)
+            .with_fn("clear", Self::clear);
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Tale(Vec<Fib>);
 
 impl Tale {
@@ -254,7 +435,7 @@ pub enum MendaxError {
         expected: Vec<&'static str>,
     },
 
-    #[error("system commands are forbidden at this sandbox level")]
+    #[error("system calls are forbidden at this sandbox level")]
     SystemForbidden,
 
     #[error("unknown colour {0:?}, expected one of: {}", .1.join(", "))]
@@ -262,6 +443,9 @@ pub enum MendaxError {
 
     #[error("keyboard interrupt")]
     KeyboardInterrupt,
+
+    #[error("cannot nest screens")]
+    NestedScreens,
 }
 
 impl From<MendaxError> for EvalAltResult {
@@ -276,9 +460,16 @@ pub enum Fib {
         cmd: String,
         result: Vec<String>,
     },
+    Show {
+        text: String,
+    },
     System {
+        apparent_cmd: Option<String>,
         cmd: String,
-        apparent_cmd: String,
+    },
+    Screen {
+        apparent_cmd: Option<String>,
+        tale: Tale,
     },
     Look {
         speed: Option<f64>,
@@ -288,6 +479,7 @@ pub enum Fib {
         cwd: Option<String>,
         user: Option<String>,
         host: Option<String>,
+        final_prompt: Option<bool>,
     },
     Clear,
 }
@@ -374,13 +566,64 @@ mod test {
     }
 
     #[test]
+    fn show() -> Result<(), Box<dyn Error>> {
+        let lie = test_script(
+            true,
+            r#"
+                lie.show("foobar");
+            "#,
+        )?;
+
+        assert_eq!(
+            lie.tale().fibs(),
+            &[Fib::Show {
+                text: "foobar".into()
+            }]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn cd() -> Result<(), Box<dyn Error>> {
+        let lie = test_script(
+            true,
+            r#"
+                lie.cd("/foo/bar");
+            "#,
+        )?;
+
+        assert_eq!(
+            lie.tale().fibs(),
+            &[
+                Fib::Run {
+                    cmd: "cd /foo/bar".into(),
+                    result: vec![],
+                },
+                Fib::Look {
+                    cwd: Some("/foo/bar".into()),
+                    speed: None,
+                    fg: None,
+                    bg: None,
+                    title: None,
+                    user: None,
+                    host: None,
+                    final_prompt: None,
+                }
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn system() -> Result<(), Box<dyn Error>> {
         {
             let lie = test_script(
                 true,
                 r#"
                     lie.system("ls");
-                    lie.system("ls -Al", "la");
+                    lie.system("la", "ls -Al");
                 "#,
             )?;
 
@@ -389,11 +632,11 @@ mod test {
                 &[
                     Fib::System {
                         cmd: "ls".into(),
-                        apparent_cmd: "ls".into(),
+                        apparent_cmd: None,
                     },
                     Fib::System {
                         cmd: "ls -Al".into(),
-                        apparent_cmd: "la".into(),
+                        apparent_cmd: Some("la".into()),
                     },
                 ]
             );
@@ -403,10 +646,87 @@ mod test {
             match test_script(false, r#"lie.system("foo");"#) {
                 Err(e) => assert_eq!(
                     e.to_string(),
-                    "mendax error: system commands are forbidden at this sandbox level"
+                    "mendax error: system calls are forbidden at this sandbox level"
                 ),
                 _ => assert!(false, "system was allowed"),
             }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn screen() -> Result<(), Box<dyn Error>> {
+        {
+            assert_eq!(
+                test_script(
+                    true,
+                    r#"
+                        lie.screen(|lie| {
+                            lie.system("ls", "sudo ls /root");
+                        });
+                    "#,
+                )?
+                .tale()
+                .fibs(),
+                &[Fib::Screen {
+                    apparent_cmd: None,
+                    tale: Tale(vec![Fib::System {
+                        cmd: "sudo ls /root".into(),
+                        apparent_cmd: Some("ls".into()),
+                    }])
+                }]
+            );
+
+            assert_eq!(
+                test_script(
+                    false,
+                    r#"
+                        lie.screen(|lie| {
+                            lie.system("ls", "sudo ls /root");
+                        });
+                    "#,
+                )
+                .unwrap_err()
+                .to_string(),
+                "mendax error: system calls are forbidden at this sandbox level",
+            );
+        }
+
+        {
+            assert_eq!(
+                test_script(
+                    true,
+                    r#"
+                        lie.screen("man foo", |lie| {
+                            lie.system("ls", "sudo ls /root");
+                        });
+                    "#,
+                )?
+                .tale()
+                .fibs(),
+                &[Fib::Screen {
+                    apparent_cmd: Some("man foo".into()),
+                    tale: Tale(vec![Fib::System {
+                        cmd: "sudo ls /root".into(),
+                        apparent_cmd: Some("ls".into()),
+                    }])
+                }]
+            );
+
+            assert_eq!(
+                test_script(
+                    false,
+                    r#"
+                        lie.screen("man foo", |lie| {
+                            lie.system("ls", "sudo ls /root");
+                        });
+                    "#,
+                )
+                .unwrap_err()
+                .to_string(),
+                "mendax error: system calls are forbidden at this sandbox level",
+            );
         }
 
         Ok(())
@@ -424,6 +744,7 @@ mod test {
                 cwd: None,
                 host: None,
                 user: None,
+                final_prompt: None,
             }],
         );
 
@@ -439,6 +760,7 @@ mod test {
                         cwd: "~/toast",
                         user: "methos",
                         host: "gaia",
+                        final_prompt: false,
                     });
                 "#
             )?
@@ -452,6 +774,7 @@ mod test {
                 cwd: Some("~/toast".into()),
                 host: Some("gaia".into()),
                 user: Some("methos".into()),
+                final_prompt: Some(false),
             }]
         );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> ExitCode {
         };
     }
 
-    let tale = match config::read(fname, args.unrestricted()) {
+    let lie = match config::read(fname, args.unrestricted()) {
         Ok(t) => t,
         Err(e) => {
             eprintln!("{}", e);
@@ -55,7 +55,7 @@ fn main() -> ExitCode {
         }
     };
 
-    match tale.tell(&mut Style::default(), &mut stdout().lock()) {
+    match lie.tell(&mut stdout().lock(), &mut Style::default()) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("{e}");


### PR DESCRIPTION
This PR adds support for `lie.screen`, which pushes a screen and temporarily performs `lie.*` commands in there, leaving the original screen untouched. This PR also adds `lie.show` which prints a string.

The `lie.screen` command has two forms:
```rhai
// Enter a new screen and show “hello, world!”
lie.screen(|lie| {
    lie.show("hello world!")
})

// Type “man foo” at a prompt then enter a screen and show “foo - the foremost bar compiler”
lie.screen("man foo", |lie| {
    lie.show("foo - the foremost bar compiler")
})
```
This PR also makes some minor consistency changes
