### PR TITLE
Rename `--unsafe` to `--unleash`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -13,7 +13,7 @@ pub struct Args {
     spec: String,
 
     /// Allow execution of arbitrary shell commands
-    #[arg(long = "unsafe")]
+    #[arg(long = "unleash")]
     unrestricted: bool,
 
     /// Output all commands which would be run


### PR DESCRIPTION
The name `--unsafe` might seem worrying to someone receiving a mendax demo. This PR changes `--unsafe` to `--unleash` to strike a balance between scariness and anticipation.
