### PR TITLE
Reinstate dry-run support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "lazy_static",
  "ncurses",
  "phf",
+ "pretty-duration",
  "pretty_assertions",
  "rand 0.8.5",
  "regex",
@@ -470,6 +471,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty-duration"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8868e7264af614b3634ff0abbe37b178e61000611b8a75221aea40221924aba"
 
 [[package]]
 name = "pretty_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ crossterm = "0.26.1"
 lazy_static = "1.4.0"
 ncurses = "5.101.0"
 phf = { version = "0.11.1", features = ["macros"] }
+pretty-duration = "0.1.1"
 rand = "0.8.5"
 rhai = { version = "1.12.0", features = ["no_module"] }
 serde = { version = "1.0.152", features = ["derive"] }

--- a/src/dry_run.rs
+++ b/src/dry_run.rs
@@ -1,4 +1,7 @@
-use crate::config::{Fib, Lie, Tale};
+use crate::{
+    lie::Lie,
+    fib::Fib,
+};
 
 pub struct DryRunBuilder {
     buf: Vec<String>,
@@ -34,15 +37,13 @@ pub trait DryRun {
 
 impl DryRun for Lie {
     fn build_dry_run(&self, builder: &mut DryRunBuilder, depth: usize) {
-        self.tale().build_dry_run(builder, depth);
+        self.fibs().build_dry_run(builder, depth);
     }
 }
 
-impl DryRun for Tale {
+impl DryRun for &[Fib] {
     fn build_dry_run(&self, builder: &mut DryRunBuilder, depth: usize) {
-        for fib in self.fibs() {
-            fib.build_dry_run(builder, depth);
-        }
+        self.iter().for_each(|fib| fib.build_dry_run(builder, depth));
     }
 }
 
@@ -67,12 +68,12 @@ impl DryRun for Fib {
                     builder.add_line(format!("! {cmd}"), depth);
                 }
             }
-            Self::Screen { apparent_cmd, tale } => {
+            Self::Screen { apparent_cmd, fibs } => {
                 if let Some(apparent_cmd) = apparent_cmd {
                     builder.add_line(format!("$ {apparent_cmd}"), depth)
                 }
                 builder.add_line("(screen)", depth);
-                tale.build_dry_run(builder, depth + 1);
+                fibs.as_slice().build_dry_run(builder, depth + 1);
             }
             Self::Look {
                 speed,
@@ -114,7 +115,10 @@ impl DryRun for Fib {
                     depth,
                 );
             }
-            Self::Tag { name } => builder.add_line(format!("@ {name}"), depth),
+            Self::Tag { name } => builder.add_line(format!("(tag) {name}"), depth),
+            Self::Sleep { duration } => builder.add_line(format!("(sleep) {}", pretty_duration::pretty_duration(duration, None)), depth),
+            Self::Stop => builder.add_line("(STOP)", depth),
+            Self::Enter { msg } => builder.add_line(format!("(enter) {msg}"), depth),
             Self::Clear => builder.add_line("(clear)", depth),
         }
     }
@@ -123,13 +127,13 @@ impl DryRun for Fib {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config;
+    use crate::lie;
     use indoc::indoc;
 
     #[test]
     fn all() {
         assert_eq!(
-            config::test::test_script(
+            lie::test::test_script(
                 true,
                 r#"
                     fn populate(lie) {
@@ -140,6 +144,9 @@ mod test {
                         lie.cd("/root");
                         lie.system("ls");
                         lie.system("ls", "dir");
+                        lie.sleep(100);
+                        lie.stop();
+                        lie.enter("asdf");
                     }
                     populate(lie);
                     lie.screen(|lie| {
@@ -166,6 +173,9 @@ mod test {
                 (look: cwd=/root)
                 ! ls
                 ! ls (secretly calls: dir)
+                (sleep) 100ms
+                (STOP)
+                (enter) asdf
                 (screen)
                     $ echo foo
                     $ echo asdf
@@ -180,6 +190,9 @@ mod test {
                     (look: cwd=/root)
                     ! ls
                     ! ls (secretly calls: dir)
+                    (sleep) 100ms
+                    (STOP)
+                    (enter) asdf
                 $ man foo
                 (screen)
                     $ echo foo
@@ -195,6 +208,9 @@ mod test {
                     (look: cwd=/root)
                     ! ls
                     ! ls (secretly calls: dir)
+                    (sleep) 100ms
+                    (STOP)
+                    (enter) asdf
             "#}
             .trim(),
         );

--- a/src/dry_run.rs
+++ b/src/dry_run.rs
@@ -1,7 +1,4 @@
-use crate::{
-    lie::Lie,
-    fib::Fib,
-};
+use crate::{fib::Fib, lie::Lie};
 
 pub struct DryRunBuilder {
     buf: Vec<String>,
@@ -43,7 +40,8 @@ impl DryRun for Lie {
 
 impl DryRun for &[Fib] {
     fn build_dry_run(&self, builder: &mut DryRunBuilder, depth: usize) {
-        self.iter().for_each(|fib| fib.build_dry_run(builder, depth));
+        self.iter()
+            .for_each(|fib| fib.build_dry_run(builder, depth));
     }
 }
 
@@ -116,7 +114,13 @@ impl DryRun for Fib {
                 );
             }
             Self::Tag { name } => builder.add_line(format!("(tag) {name}"), depth),
-            Self::Sleep { duration } => builder.add_line(format!("(sleep) {}", pretty_duration::pretty_duration(duration, None)), depth),
+            Self::Sleep { duration } => builder.add_line(
+                format!(
+                    "(sleep) {}",
+                    pretty_duration::pretty_duration(duration, None)
+                ),
+                depth,
+            ),
             Self::Stop => builder.add_line("(STOP)", depth),
             Self::Enter { msg } => builder.add_line(format!("(enter) {msg}"), depth),
             Self::Clear => builder.add_line("(clear)", depth),

--- a/src/lie.rs
+++ b/src/lie.rs
@@ -244,6 +244,10 @@ impl Lie {
         }
     }
 
+    pub fn fibs(&self) -> &[Fib] {
+        &self.fibs
+    }
+
     pub fn into_fibs(self) -> Vec<Fib> {
         self.fibs
     }
@@ -496,13 +500,6 @@ impl CustomType for SharedLie {
             .with_fn("stop", Self::stop)
             .with_fn("enter", Self::enter)
             .with_fn("clear", Self::clear);
-    }
-}
-
-#[cfg(test)]
-impl Lie {
-    pub fn fibs(&self) -> &[Fib] {
-        &self.fibs
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod args;
 mod lie;
-// mod dry_run;
+mod dry_run;
 mod error;
 mod fib;
 mod init;
@@ -14,7 +14,7 @@ extern crate pretty_assertions;
 
 use crate::args::Args;
 use clap::Parser;
-// use dry_run::DryRun;
+use dry_run::DryRun;
 use crate::tale::Tale;
 use std::io::stdout;
 use std::path::PathBuf;
@@ -37,9 +37,8 @@ fn main() -> ExitCode {
     };
 
     if args.dry_run() {
-        todo!();
-        // println!("{}", lie.dry_run());
-        // return ExitCode::SUCCESS;
+        println!("{}", lie.dry_run());
+        return ExitCode::SUCCESS;
     }
 
     match Tale::from(lie).tell(&mut stdout().lock()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 mod args;
-mod lie;
 mod dry_run;
 mod error;
 mod fib;
 mod init;
+mod lie;
 mod tale;
 
 pub use error::MendaxError;
@@ -13,9 +13,9 @@ pub use error::MendaxError;
 extern crate pretty_assertions;
 
 use crate::args::Args;
+use crate::tale::Tale;
 use clap::Parser;
 use dry_run::DryRun;
-use crate::tale::Tale;
 use std::io::stdout;
 use std::path::PathBuf;
 use std::process::ExitCode;


### PR DESCRIPTION
Dry run support was temporarily removed to simplify earlier changes; it is now reinstated.
