### PR TITLE
Reset cursor position on clear

### DIFF
--- a/src/tale.rs
+++ b/src/tale.rs
@@ -246,7 +246,7 @@ impl Tale {
                 }
                 Step::Sleep(duration) => thread::sleep(*duration),
                 Step::Stop => break,
-                Step::Clear => execute!(stdout, Clear(ClearType::All))?,
+                Step::Clear => execute!(stdout, Clear(ClearType::All), MoveTo(0, 0))?,
                 Step::ScreenOpen => {
                     execute!(stdout, SavePosition, EnterAlternateScreen, MoveTo(0, 0))?
                 }


### PR DESCRIPTION
This PR fixes a bug where clearing the screen did not reset the cursor position to the top left
